### PR TITLE
Fix modal overlay not covering top

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -535,9 +535,11 @@
     -webkit-backdrop-filter: blur(4px);
     min-height: 100vh;
     min-height: 100dvh;
+    min-height: calc(var(--vh, 1vh) * 100);
     width: 100vw;
     height: 100vh;
     height: 100dvh;
+    height: calc(var(--vh, 1vh) * 100);
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior: contain;


### PR DESCRIPTION
## Summary
- ensure modal backdrop uses dynamic viewport height so blur covers entire screen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6884f4ab1a1c8326a591dffe783fcc1f