### PR TITLE
Fix modal blur overlay spacing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -529,7 +529,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.5rem;
+    /* Remove padding so blur covers the full viewport */
+    padding: 0;
     background-color: rgba(0, 0, 0, 0.5);
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
@@ -545,13 +546,13 @@
   
   @media (min-width: 640px) {
     .modal-container {
-      padding: 1rem;
+      padding: 0;
     }
   }
-  
+
   @media (min-width: 1024px) {
     .modal-container {
-      padding: 2rem;
+      padding: 0;
     }
   }
 


### PR DESCRIPTION
## Summary
- remove padding from `.modal-container` so the backdrop blur covers the entire screen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6884f0429ab4832690ce7b33cad8fb77